### PR TITLE
Fixed segfault when input file has not been found

### DIFF
--- a/gpx-main.c
+++ b/gpx-main.c
@@ -52,9 +52,9 @@ static int sio_port = -1;
 static void exit_handler(void)
 {
     // close open files
-    if(file_in != stdin) {
+    if(file_in != stdin && file_in != NULL) {
         fclose(file_in);
-        if(file_out != stdout) {
+        if(file_out != stdout && file_out != NULL) {
             if(ferror(file_out)) {
                 perror("Error writing to output file");
             }


### PR DESCRIPTION
file_in is initialized with stdin. When opening it, a failure is
indicated by the NULL value assigned to file_in. The application
then tries to close the NULL file descriptor as it is not equal to
stdin which gives a segmentation fault.

This patch adds a check if the file descriptor is NULL and does not
try to close it if this is the case.
