### PR TITLE
changing the order of parameters in the linking helped to make it wor…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all: gpx
 
 # Main target
 gpx: $(OBJECTS)
-	$(CC) $(L_FLAGS) $(OBJECTS) -o gpx
+	$(CC) $(OBJECTS) -o gpx $(L_FLAGS)
 
 # To obtain object files
 %.o: %.c


### PR DESCRIPTION
…k with gcc

On my ubuntu linux 14.04 LTS you project failed to compile or better it failed to link. I changed the order in the makefile and put the -l to the end. That fixed it for me. Maybe that is useful for you....