### PR TITLE
-lm link flag not working solved

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all: gpx
 
 # Main target
 gpx: $(OBJECTS)
-	$(CC) $(L_FLAGS) $(OBJECTS) -o gpx
+	$(CC) $(OBJECTS) $(L_FLAGS) -o gpx
 
 # To obtain object files
 %.o: %.c


### PR DESCRIPTION
I compiled GPX on my Ubuntu 16.04 and got undefined reference to `round' errors from linker, seems -lm flag is not working.

Solved by putting link flags behind object names in the link command.